### PR TITLE
Add Laravel HTTP Client macros to consume JSON:API documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ class RecipeController extends Controller
 
 Take a look at [swisnl/json-api-client](https://github.com/swisnl/json-api-client) for more usage information.
 
+### Laravel HTTP Client
+
+You can also use the built-in [HTTP Client](https://laravel.com/docs/http-client) of Laravel if you prefer. Please note this requires Laravel 7+.
+
+``` php
+use Illuminate\Support\Facades\Http;
+use Swis\JsonApi\Client\Facades\DocumentFactoryFacade;
+use Swis\JsonApi\Client\Item;
+
+$recipe = (new Item())
+    ->setType('recipes')
+    ->fill([
+        'title' => 'Frankfurter salad with mustard dressing',
+    ]);
+
+$document = Http::asJsonApi() // Sets the Content-Type and Accept headers to 'application/vnd.api+json'.
+    ->post('https://cms.contentacms.io/api/recipes', DocumentFactoryFacade::make($recipe))
+    ->jsonApi(); // Parses the response into a JSON:API document.
+```
+
 
 ## Service Provider
 

--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Swis\JsonApi\Client\Providers;
 
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Swis\JsonApi\Client\Client;
 use Swis\JsonApi\Client\DocumentClient;
+use Swis\JsonApi\Client\Facades\ResponseParserFacade;
 use Swis\JsonApi\Client\Interfaces\ClientInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
+use Swis\JsonApi\Client\Interfaces\DocumentInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentParserInterface;
 use Swis\JsonApi\Client\Interfaces\ResponseParserInterface;
 use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
@@ -28,6 +33,8 @@ class ServiceProvider extends BaseServiceProvider
         $this->registerSharedTypeMapper();
         $this->registerParsers();
         $this->registerClients();
+
+        $this->registerLaravelHttpClientMacros();
     }
 
     public function boot()
@@ -64,5 +71,29 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->app->bind(ClientInterface::class, Client::class);
         $this->app->bind(DocumentClientInterface::class, DocumentClient::class);
+    }
+
+    protected function registerLaravelHttpClientMacros(): void
+    {
+        if (!class_exists(Http::class)) {
+            // N.B. The HTTP Client was introduced in Laravel 7.
+            return;
+        }
+
+        if (!PendingRequest::hasMacro('asJsonApi')) {
+            PendingRequest::macro('asJsonApi', function (): PendingRequest {
+                /* @var \Illuminate\Http\Client\PendingRequest $this */
+                return $this->bodyFormat('json')
+                    ->contentType('application/vnd.api+json')
+                    ->accept('application/vnd.api+json');
+            });
+        }
+
+        if (!Response::hasMacro('jsonApi')) {
+            Response::macro('jsonApi', function (): DocumentInterface {
+                /* @var \Illuminate\Http\Client\Response $this */
+                return ResponseParserFacade::parse($this->toPsrResponse());
+            });
+        }
     }
 }

--- a/tests/Providers/ServiceProviderTest.php
+++ b/tests/Providers/ServiceProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Swis\JsonApi\Client\Tests\Providers;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Swis\JsonApi\Client\Document;
+use Swis\JsonApi\Client\Tests\AbstractTest;
+
+class ServiceProviderTest extends AbstractTest
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(Http::class)) {
+            $this->markTestSkipped('The Laravel HTTP Client is not available.');
+        }
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function itRegistersHttpFacadeMacroForRequest(): void
+    {
+        // arrange
+        Http::fake();
+
+        // act
+        Http::asJsonApi()->get('https://example.com');
+
+        // assert
+        Http::assertSent(static function (Request $request) {
+            return $request->hasHeader('Content-Type', 'application/vnd.api+json') &&
+                $request->hasHeader('Accept', 'application/vnd.api+json');
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function itRegistersHttpFacadeMacroForResponse(): void
+    {
+        // arrange
+        Http::fake();
+
+        // act
+        $data = Http::get('https://example.com')->jsonApi();
+
+        // assert
+        $this->assertInstanceOf(Document::class, $data);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added JSON:API macros to the Laravel HTTP Client.

``` php
use Illuminate\Support\Facades\Http;
use Swis\JsonApi\Client\Facades\DocumentFactoryFacade;
use Swis\JsonApi\Client\Item;

$recipe = (new Item())
    ->setType('recipes')
    ->fill([
        'title' => 'Frankfurter salad with mustard dressing',
    ]);

$document = Http::asJsonApi() // Sets the Content-Type and Accept headers to 'application/vnd.api+json'.
    ->post('https://cms.contentacms.io/api/recipes', DocumentFactoryFacade::make($recipe))
    ->jsonApi(); // Parses the response into a JSON:API document.
```

## Motivation and context

This makes it easy to work with JSON:API documents using the Http facade.

## How has this been tested?

Copied from a project where I've used these macros.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
